### PR TITLE
Implement https and www redirects via settings.php

### DIFF
--- a/sites/default/drushrc.php
+++ b/sites/default/drushrc.php
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * Provide the base URL so `drush user-login` can generate a correct login link
+ * @see https://x-team.com/blog/base_url-drupal-8/
+ */
+$options['uri'] = 'https://www.neuronetupenn.org';

--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -32,6 +32,8 @@ if (file_exists($med_settings) && !file_exists($local_settings)) {
   include $med_settings;
 }
 
+unset($base_url);
+
 /**
  * If on the med (production) server, configure redirects
  * @see https://pantheon.io/docs/redirects
@@ -52,6 +54,7 @@ if (defined('MED_SERVER') && constant('MED_SERVER') && php_sapi_name() !== 'cli'
   // REMOVE AFTER TRANSITION TO NEW SITE:
   if ($_SERVER['HTTP_HOST'] === 'hosting.med.upenn.edu') {
     $requires_redirect = FALSE;
+    $base_url = 'https://hosting.med.upenn.edu/neuronet';
   }
 
   if ($requires_redirect) {

--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -31,3 +31,41 @@ $med_settings = __DIR__ . "/settings.med.php";
 if (file_exists($med_settings) && !file_exists($local_settings)) {
   include $med_settings;
 }
+
+/**
+ * If on the med (production) server, configure redirects
+ * @see https://pantheon.io/docs/redirects
+ */
+if (defined('MED_SERVER') && constant('MED_SERVER') && php_sapi_name() !== 'cli') {
+  $primary_domain = 'www.neuronetupenn.org';
+  $requires_redirect = FALSE;
+
+  if ($_SERVER['HTTP_HOST'] !== $primary_domain) {
+    $requires_redirect = TRUE;
+  }
+
+  if (empty($_SERVER['HTTPS'] || $_SERVER['HTTPS'] === 'off')
+      && $_SERVER['SERVER_PORT'] === 80) {
+    $requires_redirect = TRUE;
+  }
+
+  // REMOVE AFTER TRANSITION TO NEW SITE:
+  if ($_SERVER['HTTP_HOST'] === 'hosting.med.upenn.edu') {
+    $requires_redirect = FALSE;
+  }
+
+  if ($requires_redirect) {
+    header('HTTP/1.0 301 Moved Permanently');
+    header('Location: https://' . $primary_domain . $_SERVER['REQUEST_URI']);
+    exit();
+  }
+
+  // Drupal 8 Trusted Host Settings
+  if (is_array($settings)) {
+    $settings['trusted_host_patterns'] = array(
+      '^' . preg_quote($primary_domain) . '$'
+      // REMOVE AFTER TRANSITION TO NEW SITE:
+      , '^hosting\.med\.upenn\.edu$'
+    );
+  }
+}


### PR DESCRIPTION
Based on the Pantheon guide - this should force all http and bare URL requests on the new site to redirect to https://www.neuronetupenn.org. Also unsets $base_url for now (when settings.med.php is editable on the server I can change it directly there). Allows the old URL to pass through unchanged for now.