### PR TITLE
Better deploy git commands

### DIFF
--- a/.docksal/commands/deploy-prod
+++ b/.docksal/commands/deploy-prod
@@ -124,12 +124,12 @@ server_code=$(cat << EOF
     trap cleanup EXIT &&
 
     echo &&
-    echo Updating prod database... &&
-    drush updb -y &&
-
-    echo &&
     echo Importing config on prod site... &&
     drush cim -y &&
+
+    echo &&
+    echo Updating prod database... &&
+    drush updb -y &&
 
     echo Cache-rebuilding... &&
     drush cr &&

--- a/.docksal/commands/deploy-prod
+++ b/.docksal/commands/deploy-prod
@@ -108,6 +108,8 @@ server_code=$(cat << EOF
     git fetch $remote &&
     git checkout -f $remote/$branch &&
     git reset --hard &&
+    git branch -f $branch &&
+    git checkout $branch &&
 
     echo &&
     echo Running composer install... &&

--- a/.docksal/commands/deploy-test
+++ b/.docksal/commands/deploy-test
@@ -89,6 +89,8 @@ server_code=$(cat << EOF
 	git fetch dev &&
 	git checkout -f dev/$branch &&
 	git reset --hard &&
+	git branch -f $branch &&
+	git checkout $branch &&
 
 	echo &&
 	echo Running composer install... &&

--- a/.docksal/commands/deploy-test
+++ b/.docksal/commands/deploy-test
@@ -102,15 +102,15 @@ server_code=$(cat << EOF
 		drush sql-query --file=$test_dump;
 	} &&
 	trap cleanup EXIT &&
+	
+	echo &&
+	echo Importing config files... &&
+	drush cim -y &&
 
 	echo &&
 	echo Updating database... &&
 	cd - &&
 	drush updb -y &&
-
-	echo &&
-	echo Importing config files... &&
-	drush cim -y &&
 
 	echo &&
 	echo Cache-rebuilding... &&


### PR DESCRIPTION
Add some git commands for the deploy scripts to always put test and prod sites on a branch (matching the upstream name) when deploying, to make it easier to commit and push config changes on the server when necessary.

Also change the order of importing config and updating the database, to avoid an error I encountered while deploying this. There is a config file that specifies which modules are enabled, and if the database is updated before updating that to match when the installed modules have changed, Drupal will complain.